### PR TITLE
Remove usage of Text.IO for files and decodeUtf8

### DIFF
--- a/ff-core/lib/FF/Github.hs
+++ b/ff-core/lib/FF/Github.hs
@@ -47,10 +47,14 @@ getIssues mAddress mlimit issueState = do
     address <- case mAddress of
         Just address -> pure address
         Nothing      -> do
-            url <- liftIO $
-                fmap (Text.strip . TextL.toStrict . TextL.decodeUtf8) $
+            url' <-
+                liftIO $
+                fmap TextL.decodeUtf8' $
                 readProcessStdout_ $
                 proc "git" ["remote", "get-url", "--push", "origin"]
+            url <-
+                Text.strip . TextL.toStrict
+                <$> either (throwError . Text.pack . show) pure url'
             case url of
                 (stripPrefixSuffix "https://github.com/" ".git" -> Just repo) ->
                     pure repo


### PR DESCRIPTION
Problem: `Text.IO` is locale-dependent, `decodeUtf8` is partial.

Solution: replace `Text.IO` with `ByteString` IO for files, replace `decodeUtf8`
with `decodeUtf8'` and `decodeUtf8With`.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ff-notes/ff/211)
<!-- Reviewable:end -->
