### PR TITLE
Add support for command line options for external editor

### DIFF
--- a/ff-core/lib/FF/CLI.hs
+++ b/ff-core/lib/FF/CLI.hs
@@ -417,7 +417,14 @@ runExternalEditor textOld =
 
     assertExecutableFromConfig = do
       cfg <- loadConfig
-      maybe empty assertExecutable $ externalEditor cfg
+      let eEditor = do
+            editor <- maybe empty ShellWords.parse $ externalEditor cfg
+            maybe (Left "empty") Right $ nonEmpty editor
+      case eEditor of
+        Left err -> do
+          hPutStrLn stderr $ "error in externalEditor configuration: " <> err
+          empty
+        Right editor@(prog :| _) -> assertExecutable prog $> editor
 
     assertExecutableFromEnv var = do
       editorCmd <- getEnv var


### PR DESCRIPTION
This adds  command line options support for external editor configuration, so you can enter something like `ff config externalEditor "code -n -w"`

This is more of a copy & paste than original code. I am new to Haskell, so I appreciate any pointers/suggestions/criticisms that can help me improve.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ff-notes/ff/231)
<!-- Reviewable:end -->
